### PR TITLE
Switching quotations to backtick

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.32</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/src/main/java/com/yahoo/gsheetjdbc/loader/DatabaseLoader.java
+++ b/src/main/java/com/yahoo/gsheetjdbc/loader/DatabaseLoader.java
@@ -88,14 +88,14 @@ public class DatabaseLoader implements Closeable {
 
     String generateTableName(Table table, String suffix) {
         StringBuilder statement = new StringBuilder();
-        statement.append("\"");
+        statement.append("`");
         statement.append(table.getSchema());
-        statement.append("\".\"");
+        statement.append("`.`");
         statement.append(table.getTableName());
         if (suffix != null) {
             statement.append(suffix);
         }
-        statement.append("\"");
+        statement.append("`");
         return statement.toString();
     }
 
@@ -117,9 +117,9 @@ public class DatabaseLoader implements Closeable {
 
     String generateSchemaGenerationStatement(Table table) {
         StringBuilder statement = new StringBuilder();
-        statement.append("CREATE SCHEMA IF NOT EXISTS \"");
+        statement.append("CREATE SCHEMA IF NOT EXISTS `");
         statement.append(table.getSchema());
-        statement.append("\";");
+        statement.append("`;");
 
         return statement.toString();
     }
@@ -132,7 +132,7 @@ public class DatabaseLoader implements Closeable {
 
         statement.append(table.getColumns().stream().map(
                 column -> {
-                    return "\"" + column.getName() + "\" " + getH2Type(column.getType());
+                    return "`" + column.getName() + "` " + getH2Type(column.getType());
                 }
         ).collect(Collectors.joining(",")));
 
@@ -149,7 +149,7 @@ public class DatabaseLoader implements Closeable {
         statement.append(" (");
         statement.append(table.getColumns().stream().map(
                 column -> {
-                    return "\"" + column.getName() + "\"";
+                    return "`" + column.getName() + "`";
                 }
         ).collect(Collectors.joining(",")));
 

--- a/src/test/java/com/yahoo/gsheetjdbc/driver/DriverIT.java
+++ b/src/test/java/com/yahoo/gsheetjdbc/driver/DriverIT.java
@@ -24,7 +24,7 @@ public class DriverIT {
         String url = "jdbc:gsheet://doc=(id=1Is6tUtJxhmjN8f4nqIYq-6n7FcW17y8glK1F9EsHzr4,range=Class%20Data!A1:I31)/MySchema";
         Connection connection = DriverManager.getConnection(url, "", "");
 
-        PreparedStatement statement = connection.prepareStatement("Select * from \"MySchema\".\"Class Data\" WHERE \"Student Name\"='Alexandra' LIMIT 1;");
+        PreparedStatement statement = connection.prepareStatement("Select * from `MySchema`.`Class Data` WHERE `Student Name`='Alexandra' LIMIT 1;");
 
         ResultSet result = statement.executeQuery();
         assertEquals(true, result.last());
@@ -39,7 +39,7 @@ public class DriverIT {
         String url = "jdbc:gsheet://doc=(id=1Is6tUtJxhmjN8f4nqIYq-6n7FcW17y8glK1F9EsHzr4,range=Class%20Data!A1:I31),doc=(id=1Is6tUtJxhmjN8f4nqIYq-6n7FcW17y8glK1F9EsHzr4,range=Drum%20Inventory!A1:C5)/MySchema";
         Connection connection = DriverManager.getConnection(url, "", "");
 
-        PreparedStatement statement = connection.prepareStatement("Select * from \"MySchema\".\"Class Data\" WHERE \"Student Name\"='Alexandra' LIMIT 1;");
+        PreparedStatement statement = connection.prepareStatement("Select * from `MySchema`.`Class Data` WHERE `Student Name`='Alexandra' LIMIT 1;");
 
         ResultSet result = statement.executeQuery();
         assertEquals(true, result.last());
@@ -47,7 +47,7 @@ public class DriverIT {
         assertEquals(100.0, result.getDouble(7));
 
 
-        statement = connection.prepareStatement("Select SUM(\"Price\") AS total from \"MySchema\".\"Drum Inventory\";");
+        statement = connection.prepareStatement("Select SUM(`Price`) AS total from `MySchema`.`Drum Inventory`;");
 
         result = statement.executeQuery();
         assertEquals(true, result.last());
@@ -76,7 +76,7 @@ public class DriverIT {
         //Reload the data...
         connection = DriverManager.getConnection(url, "", "");
 
-        PreparedStatement statement = connection.prepareStatement("Select \"Earnings\" from \"MySchema\".\"Class Data\" WHERE \"Student Name\"='Alexandra' LIMIT 1;");
+        PreparedStatement statement = connection.prepareStatement("Select `Earnings` from `MySchema`.`Class Data` WHERE `Student Name`='Alexandra' LIMIT 1;");
 
         ResultSet result = statement.executeQuery();
         assertEquals(true, result.last());

--- a/src/test/java/com/yahoo/gsheetjdbc/loader/DatabaseLoaderTest.java
+++ b/src/test/java/com/yahoo/gsheetjdbc/loader/DatabaseLoaderTest.java
@@ -49,7 +49,7 @@ public class DatabaseLoaderTest {
     public void testCreateTableSql() {
         DatabaseLoader loader = new DatabaseLoader("test");
 
-        String expected = "CREATE TABLE IF NOT EXISTS \"MySchema\".\"MyTable\" (\"exampleText\" VARCHAR,\"exampleBoolean\" BOOLEAN,\"exampleNumber\" DOUBLE,\"exampleDate\" DATE,\"exampleDateTime\" TIMESTAMP);";
+        String expected = "CREATE TABLE IF NOT EXISTS `MySchema`.`MyTable` (`exampleText` VARCHAR,`exampleBoolean` BOOLEAN,`exampleNumber` DOUBLE,`exampleDate` DATE,`exampleDateTime` TIMESTAMP);";
         assertEquals(expected, loader.generateTableCreationStatement(table, ""));
     }
 
@@ -57,7 +57,7 @@ public class DatabaseLoaderTest {
     public void testCreateSchemaSql() {
         DatabaseLoader loader = new DatabaseLoader("test");
 
-        String expected = "CREATE SCHEMA IF NOT EXISTS \"MySchema\";";
+        String expected = "CREATE SCHEMA IF NOT EXISTS `MySchema`;";
         assertEquals(expected, loader.generateSchemaGenerationStatement(table));
     }
 
@@ -65,7 +65,7 @@ public class DatabaseLoaderTest {
     public void testTableRenameSql() {
         DatabaseLoader loader = new DatabaseLoader("test");
 
-        String expected = "ALTER TABLE IF EXISTS \"MySchema\".\"MyTableFoo\" RENAME TO \"MySchema\".\"MyTableBar\"";
+        String expected = "ALTER TABLE IF EXISTS `MySchema`.`MyTableFoo` RENAME TO `MySchema`.`MyTableBar`";
         assertEquals(expected, loader.generateTableRenameStatement(table, "Foo", "Bar"));
     }
 
@@ -73,7 +73,7 @@ public class DatabaseLoaderTest {
     public void testTableDropSql() {
         DatabaseLoader loader = new DatabaseLoader("test");
 
-        String expected = "DROP TABLE IF EXISTS \"MySchema\".\"MyTableFoo\"";
+        String expected = "DROP TABLE IF EXISTS `MySchema`.`MyTableFoo`";
         assertEquals(expected, loader.generateTableDropStatement(table, "Foo"));
     }
 
@@ -81,7 +81,7 @@ public class DatabaseLoaderTest {
     public void testInsertTableSql() {
         DatabaseLoader loader = new DatabaseLoader("test");
 
-        String expected = "INSERT INTO \"MySchema\".\"MyTable\" (\"exampleText\",\"exampleBoolean\",\"exampleNumber\",\"exampleDate\",\"exampleDateTime\") VALUES (?,?,?,?,?);";
+        String expected = "INSERT INTO `MySchema`.`MyTable` (`exampleText`,`exampleBoolean`,`exampleNumber`,`exampleDate`,`exampleDateTime`) VALUES (?,?,?,?,?);";
         assertEquals(expected, loader.generateTableInsertionStatement(table, ""));
     }
 
@@ -113,7 +113,7 @@ public class DatabaseLoaderTest {
 
         PreparedStatement statement = null;
         try (Connection connection = loader.getConnection()) {
-            statement = connection.prepareStatement("SELECT COUNT(*) FROM \"MySchema\".\"MyTable\";");
+            statement = connection.prepareStatement("SELECT COUNT(*) FROM `MySchema`.`MyTable`;");
 
             ResultSet result = statement.executeQuery();
             assertTrue(result.last());

--- a/src/test/resources/apiResponses/employeeData.json
+++ b/src/test/resources/apiResponses/employeeData.json
@@ -15,7 +15,8 @@
                   "effectiveFormat": {
                     "numberFormat": {
                       "pattern":"M/d/yyyy",
-                      "type":"DATE"}
+                      "type":"DATE"
+                    }
                   },
                   "effectiveValue": {
                     "stringValue":"Hire Date"


### PR DESCRIPTION
The Elide H2 dialect uses backtick instead of double quotes to quote identifiers.  This PR brings the two in sync.